### PR TITLE
Add option for collapsed height > 0

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -10,6 +10,7 @@ const Collapse = React.createClass({
   propTypes: {
     isOpened: React.PropTypes.bool.isRequired,
     children: React.PropTypes.node.isRequired,
+    collapsedHeight: React.PropTypes.number,
     fixedHeight: React.PropTypes.number,
     style: React.PropTypes.object,
     springConfig: React.PropTypes.arrayOf(React.PropTypes.number)
@@ -17,7 +18,7 @@ const Collapse = React.createClass({
 
 
   getDefaultProps() {
-    return {fixedHeight: -1, style: {}};
+    return {fixedHeight: -1, style: {}, collapsedHeight: 0};
   },
 
 
@@ -39,12 +40,13 @@ const Collapse = React.createClass({
 
 
   renderFixed() {
-    const {isOpened, style, children, fixedHeight, springConfig, ...props} = this.props;
+    const {isOpened, style, children, fixedHeight,
+      collapsedHeight, springConfig, ...props} = this.props;
 
     return (
       <Motion
-        defaultStyle={{height: 0}}
-        style={{height: spring(isOpened ? fixedHeight : 0, springConfig)}}>
+        defaultStyle={{height: collapsedHeight}}
+        style={{height: spring(isOpened ? fixedHeight : collapsedHeight, springConfig)}}>
         {({height}) => (!isOpened && parseFloat(height).toFixed(1) === '0.0') ? null : (
           <div style={{...style, height, overflow: 'hidden'}} {...props}>
             {children}
@@ -56,7 +58,8 @@ const Collapse = React.createClass({
 
 
   render() {
-    const {isOpened, style, children, fixedHeight, springConfig, ...props} = this.props;
+    const {isOpened, style, children, fixedHeight,
+      collapsedHeight, springConfig, ...props} = this.props;
 
     if (fixedHeight > -1) {
       return this.renderFixed();
@@ -74,8 +77,8 @@ const Collapse = React.createClass({
 
     return (
       <Motion
-        defaultStyle={{height: 0}}
-        style={{height: spring(isOpened ? height : 0, springConfig)}}>
+        defaultStyle={{height: collapsedHeight}}
+        style={{height: spring(isOpened ? height : collapsedHeight, springConfig)}}>
         {st => {
           this.height = Math.max(0, parseFloat(st.height)).toFixed(1);
 

--- a/src/example/App.js
+++ b/src/example/App.js
@@ -5,6 +5,7 @@ import VariableHeight from './VariableHeight';
 import FixedHeight from './FixedHeight';
 import SpringConfig from './SpringConfig';
 import Nested from './Nested';
+import CollapsedHeight from './CollapsedHeight';
 
 
 const style = {
@@ -48,6 +49,11 @@ const App = React.createClass({
         <section style={style.section}>
           <h2>Example 5. Nested Collapse</h2>
           <Nested />
+        </section>
+
+        <section style={style.section}>
+          <h2>Example 6. CollapsedHeight</h2>
+          <CollapsedHeight />
         </section>
 
       </div>

--- a/src/example/CollapsedHeight.js
+++ b/src/example/CollapsedHeight.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import {shouldComponentUpdate} from 'react-addons-pure-render-mixin';
+import Collapse from '..';
+import * as style from './style';
+
+
+const localStyle = height => ({
+  content: {
+    height,
+    background: 'rgba(96, 125, 139, 0.6)',
+    borderRadius: height / 2
+  }
+});
+
+
+const FixedHeight = React.createClass({
+  getInitialState() {
+    return {isOpened: false, content: 100, collapse: 200};
+  },
+
+
+  shouldComponentUpdate,
+
+
+  onChangeContent({target: {value}}) {
+    this.setState({content: parseInt(value, 10)});
+  },
+
+
+  onChangeCollapse({target: {value}}) {
+    this.setState({collapse: parseInt(value, 10)});
+  },
+
+
+  render() {
+    const {isOpened, collapse, content} = this.state;
+
+    return (
+      <div>
+
+        <div style={style.config}>
+          <button onClick={() => this.setState({isOpened: !isOpened})}>Toggle</button>
+          &nbsp;
+          Content height:
+          &nbsp;
+          <input type="range" step={50} min={0} max={500}
+            value={content} onChange={this.onChangeContent} />
+          &nbsp;
+          Collapsed height:
+          &nbsp;
+          <input type="range" step={50} min={0} max={500}
+            value={collapse} onChange={this.onChangeCollapse} />
+        </div>
+
+        <Collapse isOpened={isOpened} style={style.container} collapsedHeight={collapse}>
+          <div style={{...localStyle(content).content, height: content}}></div>
+        </Collapse>
+
+      </div>
+    );
+  }
+});
+
+
+export default FixedHeight;


### PR DESCRIPTION
This allows you to have a collapsed height of > 0, if you want to
toggle between an element of height `y` and the height of a variable
height content.