### PR TITLE
don't animate into place if the component mounts open

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import {shouldComponentUpdate} from 'react-addons-pure-render-mixin';
 import {Motion, spring} from 'react-motion';
-
-
 import HeightReporter from 'react-height';
-
 
 const Collapse = React.createClass({
   propTypes: {
@@ -22,7 +19,7 @@ const Collapse = React.createClass({
 
 
   getInitialState() {
-    return {height: -1};
+    return {height: -1, staticRendering: true, startsOpen: this.props.isOpened};
   },
 
   componentWillMount() {
@@ -34,7 +31,7 @@ const Collapse = React.createClass({
 
 
   onHeightReady(height) {
-    this.setState({height});
+    this.setState({height, staticRendering: false});
   },
 
 
@@ -62,7 +59,7 @@ const Collapse = React.createClass({
       return this.renderFixed();
     }
 
-    const {height} = this.state;
+    const {height, staticRendering, startsOpen} = this.state;
     const stringHeight = parseFloat(height).toFixed(1);
 
     // Cache Content so it is not re-rendered on each animation step
@@ -72,9 +69,13 @@ const Collapse = React.createClass({
       </HeightReporter>
     );
 
+    if (staticRendering && isOpened) {
+      return <div style={style} {...props}>{content}</div>;
+    }
+
     return (
       <Motion
-        defaultStyle={{height: 0}}
+        defaultStyle={{height: startsOpen ? height : 0}}
         style={{height: spring(isOpened ? height : 0, springConfig)}}>
         {st => {
           this.height = Math.max(0, parseFloat(st.height)).toFixed(1);

--- a/src/example/VariableHeight.js
+++ b/src/example/VariableHeight.js
@@ -14,7 +14,7 @@ const localStyle = height => ({
 
 const VariableHeight = React.createClass({
   getInitialState() {
-    return {isOpened: false, height: 100};
+    return {isOpened: true, height: 100};
   },
 
 


### PR DESCRIPTION
I encountered an issue when initializing a Collapse element with content and isOpened=true, it would animate into place. It would initialize with a height of 0 and then expand from there. I didn't want that behavior, and I don't know why anybody would want that behavior, so I fixed it. This might be better suited as an optional feature, but again, don't know why people would want current behavior.