### PR TITLE
Fix unwanted animation if isOpened state is unchanged, fixes #21

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -30,6 +30,13 @@ const Collapse = React.createClass({
   },
 
 
+  componentWillReceiveProps({isOpened}) {
+    if (isOpened === this.props.isOpened) {
+      this.renderStatic = true;
+    }
+  },
+
+
   shouldComponentUpdate,
 
 


### PR DESCRIPTION
fixes #21

![fix-unwanted-animation](https://cloud.githubusercontent.com/assets/175264/11917723/5603b032-a767-11e5-9811-362b39cd5cf4.gif)


Basically if props were updated but isOpened did not change, then treat is in the same way as freshly rendered component (render as static)