### PR TITLE
Avoid setting height to 0 so we don't miss toggling open

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -54,13 +54,15 @@ const Collapse = React.createClass({
   },
 
   onHeightReady(height) {
-    const {isOpened} = this.props;
+    const {isOpened, keepCollapsedContent} = this.props;
 
     if (this.renderStatic && isOpened) {
       this.height = stringHeight(height);
     }
-    if (this.state.height !== height) {
+    if (keepCollapsedContent) {
       this.setState({height});
+    } else {
+      this.setState({height: isOpened || !this.renderStatic ? height : 0});
     }
 
     const reportHeight = this.props.isOpened ? height : 0;

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -54,15 +54,13 @@ const Collapse = React.createClass({
   },
 
   onHeightReady(height) {
-    const {isOpened, keepCollapsedContent} = this.props;
+    const {isOpened} = this.props;
 
     if (this.renderStatic && isOpened) {
       this.height = stringHeight(height);
     }
-    if (keepCollapsedContent) {
+    if (this.state.height !== height) {
       this.setState({height});
-    } else {
-      this.setState({height: isOpened ? height : 0});
     }
 
     const reportHeight = this.props.isOpened ? height : 0;


### PR DESCRIPTION
Nice lib @nkbt !

One problem I'm having though is when the component is first mounted with `isOpened` set to `true`, and then I subsequently toggle `isOpened` to `false` and then back to `true` before the animation has completed, it goes a little wonky. You can see the problem here:

![dropdown-animation-test-bad](https://cloud.githubusercontent.com/assets/404605/15270887/5db15900-19f5-11e6-9528-b63e86d563ee.gif)

Notice how it animates closed, but then it opens without any animation. After that, closing it again doesn't animate, but then the next open does animate. (And after that it works fine.)

The problem is that the component first mounts without `Motion`, so when you first toggle it closed, it then mounts with `Motion` and then gets a new `HeightReporter`. The new `HeightReporter` sets the `height` to `0`. If you toggle before the content is removed, it will still have a target of `0`, so it animates to `0` and then blinks back open. If you wait for the animation to fall to `0` before toggling, then it works fine, because it mounts a brand-new `HeightReporter` which causes the state to be set to the correct height.

In this PR, I just avoid setting the height to `0`. (I also avoid setting it to a value that's the same, but that's not strictly necessary.) That makes the animation work correctly:

![dropdown-animation-test-good](https://cloud.githubusercontent.com/assets/404605/15270920/af91cefc-19f6-11e6-9256-268d19efb5f9.gif)

Not sure what the thinking was on setting the height to `0` in that case. But since it was inconsistent anyway, if that's really necessary, it might be better to detect when `HeightReporter` unmounts and set the height to `0` at that point.