### PR TITLE
Reduce Spring precision

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -4,6 +4,9 @@ import {Motion, spring} from 'react-motion';
 import HeightReporter from 'react-height';
 
 
+const PRECISION = 0.5;
+
+
 const stringHeight = height => Math.max(0, parseFloat(height)).toFixed(1);
 
 
@@ -83,7 +86,10 @@ const Collapse = React.createClass({
     // Also no need to animate if height did not change
     const skipAnimation = !isOpenedChanged && !isOpened || this.height === newHeight;
 
-    const springHeight = spring(isOpened ? Math.max(0, height) : 0, springConfig);
+    const springHeight = spring(isOpened ? Math.max(0, height) : 0, {
+      precision: PRECISION,
+      ...springConfig
+    });
     const instantHeight = isOpened ? Math.max(0, height) : 0;
 
     return skipAnimation ? instantHeight : springHeight;


### PR DESCRIPTION
For collapse animation 0.01px precision does not make much sense, so reduce it to 0.5 for perf improvement and less calculations