### PR TITLE
ReactMotion around static render

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -181,6 +181,7 @@ const Collapse = React.createClass({
         if (!keepCollapsedContent) {
           return null;
         }
+
         return (
           <div style={{height: 0, overflow: 'hidden', ...style}} {...props}>
             {content}
@@ -188,7 +189,17 @@ const Collapse = React.createClass({
         );
       }
 
-      return <div style={{...newStyle, ...style}} {...props}>{content}</div>;
+      // <Motion> to prevent loosing input after causing this component to rerender
+      return (
+        <Motion
+          defaultStyle={{height: Math.max(0, height)}}
+          style={{height: Math.max(0, height)}}
+          onRest={onRest}>
+          {() =>
+            <div style={{...newStyle, ...style}} {...props}>{content}</div>
+          }
+        </Motion>
+      );
     }
 
     return (
@@ -207,7 +218,7 @@ const Collapse = React.createClass({
             }
             return (
               <div style={{height: 0, overflow: 'hidden', ...style}} {...props}>
-                {content}
+              {content}
               </div>
             );
           }


### PR DESCRIPTION
As mentioned in #60, when Collapse is rendered statically there is no `Motion` component around content. When component will be updated component is not rendered statically anymore because only first render is static according to https://github.com/nkbt/react-collapse#behaviour-notes. I found possible fix which is wrapping first static render when component `isOpened` into `Motion` component, this will prevent focus lost on children components.