### PR TITLE
Add back fixedHeight

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ One or multiple children with static, variable or dynamic height.
 ```
 
 
+#### `fixedHeight`: PropTypes.number
+
+If content's height is known ahead it is possible pass optional `fixedHeight` prop with number of pixels.
+
+```js
+<Collapse isOpened={true} fixedHeight={100}>
+  <div>Animated container will always expand to 100px height</div>
+</Collapse>
+```
+
+
 #### `springConfig`: React.PropTypes.objectOf(React.PropTypes.number)
 
 Custom config `{stiffness, damping, precision}` passed to the spring function (see https://github.com/chenglou/react-motion#--spring-val-number-config-springhelperconfig--opaqueconfig)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ then include as
 Default behaviour, never unmounts content
 
 ```js
-import Collapse from 'react-collapse';
+import {Collapse} from 'react-collapse';
 
 // ...
 <Collapse isOpened={true || false}>

--- a/src/example/App/FixedHeight.js
+++ b/src/example/App/FixedHeight.js
@@ -3,9 +3,9 @@ import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin
 import {Collapse} from '../..';
 
 
-export const VariableHeight = React.createClass({
+export const FixedHeight = React.createClass({
   getInitialState() {
-    return {isOpened: false, height: 100};
+    return {isOpened: false, height: 100, fixedHeight: 200};
   },
 
 
@@ -13,7 +13,7 @@ export const VariableHeight = React.createClass({
 
 
   render() {
-    const {isOpened, height} = this.state;
+    const {isOpened, height, fixedHeight} = this.state;
 
     return (
       <div {...this.props}>
@@ -34,9 +34,18 @@ export const VariableHeight = React.createClass({
               onChange={({target: {value}}) => this.setState({height: parseInt(value, 10)})} />
             {height}
           </label>
+
+          <label className="label">
+            Collapse height:
+            <input className="input"
+              type="range"
+              value={fixedHeight} step={50} min={0} max={500}
+              onChange={({target: {value}}) => this.setState({fixedHeight: parseInt(value, 10)})} />
+            {fixedHeight}
+          </label>
         </div>
 
-        <Collapse isOpened={isOpened}>
+        <Collapse isOpened={isOpened} fixedHeight={fixedHeight}>
           <div style={{height}} className="blob" />
         </Collapse>
 

--- a/src/example/App/Hooks.js
+++ b/src/example/App/Hooks.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
-import Collapse from '../..';
+import {Collapse} from '../..';
 import text from './text.json';
 
 
 const getText = num => text.slice(0, num).map((p, i) => <p key={i}>{p}</p>);
 
 
-const Hooks = React.createClass({
+export const Hooks = React.createClass({
   getInitialState() {
     return {
       isOpened: false,
@@ -97,6 +97,3 @@ const Hooks = React.createClass({
     );
   }
 });
-
-
-export default Hooks;

--- a/src/example/App/InitiallyOpened.js
+++ b/src/example/App/InitiallyOpened.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
-import Collapse from '../..';
+import {Collapse} from '../..';
 
 
-const InitiallyOpened = React.createClass({
+export const InitiallyOpened = React.createClass({
   getInitialState() {
     return {isOpened: true};
   },
@@ -34,6 +34,3 @@ const InitiallyOpened = React.createClass({
     );
   }
 });
-
-
-export default InitiallyOpened;

--- a/src/example/App/Issue40.js
+++ b/src/example/App/Issue40.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
-import Collapse from '../..';
-import VariableHeight from './VariableHeight';
+import {Collapse} from '../..';
+import {VariableHeight} from './VariableHeight';
 
 
 export const Issue40 = React.createClass({

--- a/src/example/App/Issue59.js
+++ b/src/example/App/Issue59.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
-import Collapse from '../..';
+import {Collapse} from '../..';
 
 
 const styles = {

--- a/src/example/App/Issue66.js
+++ b/src/example/App/Issue66.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Collapse from '../..';
+import {Collapse} from '../..';
 
 
 const Test = React.createClass({

--- a/src/example/App/Nested.js
+++ b/src/example/App/Nested.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
-import Collapse from '../..';
-import VariableHeight from './VariableHeight';
+import {Collapse} from '../..';
+import {VariableHeight} from './VariableHeight';
 
 
-const Nested = React.createClass({
+export const Nested = React.createClass({
   getInitialState() {
     return {isOpened: false};
   },
@@ -37,6 +37,3 @@ const Nested = React.createClass({
     );
   }
 });
-
-
-export default Nested;

--- a/src/example/App/SpringConfig.js
+++ b/src/example/App/SpringConfig.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import {presets} from 'react-motion';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
-import Collapse from '../..';
+import {Collapse} from '../..';
 
 
-const VariableHeight = React.createClass({
+export const SpringConfig = React.createClass({
   getInitialState() {
     const preset = 'stiff';
     const {stiffness, damping} = presets[preset];
@@ -84,6 +84,3 @@ const VariableHeight = React.createClass({
     );
   }
 });
-
-
-export default VariableHeight;

--- a/src/example/App/VariableText.js
+++ b/src/example/App/VariableText.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Collapse from '../..';
+import {Collapse} from '../..';
 import text from './text.json';
 
 
@@ -7,7 +7,7 @@ const getText = num => text.slice(0, num)
   .map((p, i) => <p key={i}>{p}</p>);
 
 
-const VariableText = React.createClass({
+export const VariableText = React.createClass({
   propTypes: {
     isOpened: React.PropTypes.bool
   },
@@ -58,6 +58,3 @@ const VariableText = React.createClass({
     );
   }
 });
-
-
-export default VariableText;

--- a/src/example/App/index.js
+++ b/src/example/App/index.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import VariableText from './VariableText';
-import VariableHeight from './VariableHeight';
-import InitiallyOpened from './InitiallyOpened';
-import SpringConfig from './SpringConfig';
-import Nested from './Nested';
-import Hooks from './Hooks';
+import {VariableText} from './VariableText';
+import {VariableHeight} from './VariableHeight';
+import {FixedHeight} from './FixedHeight';
+import {InitiallyOpened} from './InitiallyOpened';
+import {SpringConfig} from './SpringConfig';
+import {Nested} from './Nested';
+import {Hooks} from './Hooks';
 import {AutoUnmount} from './AutoUnmount';
 
 import {Issue40} from './Issue40';
@@ -14,7 +15,7 @@ import {Issue66} from './Issue66';
 import {name} from '../../../package.json';
 
 
-const App = React.createClass({
+export const App = React.createClass({
   render() {
     return (
       <div className="app">
@@ -34,6 +35,11 @@ const App = React.createClass({
         <section className="section">
           <h2>3. Variable height content</h2>
           <VariableHeight />
+        </section>
+
+        <section className="section">
+          <h2>4. Fixed height content</h2>
+          <FixedHeight />
         </section>
 
         <section className="section">
@@ -100,6 +106,3 @@ const App = React.createClass({
     );
   }
 });
-
-
-export default App;

--- a/src/example/Example.js
+++ b/src/example/Example.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
+import {App} from './App';
 
 import './reset.css';
 import './app.css';

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const {Collapse} = require('./Collapse');
 const {Unmount} = require('./Unmount');
 
 
+Collapse.Collapse = Collapse;
 Collapse.CollapseUnmountClosed = Unmount;
 
 


### PR DESCRIPTION
It was actually pretty straightforward to put back `fixedHeight`. Yeah, it might be easier just to use  pure ReactMotion for that, since height is known, but we don't want to lose all the extra functionality like "onMeasure", "onRest", "onRender" callbacks and other things.