### PR TITLE
Rename to UnmountClosed

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ import {Collapse} from 'react-collapse';
 If you want to unmount collapsed content, use `Unmount` component provided as:
 
 ```js
-import {CollapseUnmountClosed} from 'react-collapse';
+import {UnmountClosed} from 'react-collapse';
 
 // ...
-<CollapseUnmountClosed isOpened={true || false}>
+<UnmountClosed isOpened={true || false}>
   <div>Random content</div>
-</CollapseUnmountClosed>
+</UnmountClosed>
 ```
 
 ## Options

--- a/src/UnmountClosed.js
+++ b/src/UnmountClosed.js
@@ -3,7 +3,7 @@ import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin
 import {Collapse} from './Collapse';
 
 
-export const Unmount = React.createClass({
+export const UnmountClosed = React.createClass({
   propTypes: {
     isOpened: React.PropTypes.bool.isRequired,
     onRest: React.PropTypes.func

--- a/src/example/App/AutoUnmount.js
+++ b/src/example/App/AutoUnmount.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {CollapseUnmountClosed} from '../..';
+import {UnmountClosed} from '../..';
 
 
 const Test = React.createClass({
@@ -84,9 +84,9 @@ export const AutoUnmount = React.createClass({
           </label>
         </div>
 
-        <CollapseUnmountClosed isOpened={isOpened}>
+        <UnmountClosed isOpened={isOpened}>
           <Test onMount={this.onMount} onUnmount={this.onUnmount} />
-        </CollapseUnmountClosed>
+        </UnmountClosed>
 
         <div className="log" ref={this.onRef} />
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,11 @@
 
 
 const {Collapse} = require('./Collapse');
-const {Unmount} = require('./Unmount');
+const {UnmountClosed} = require('./UnmountClosed');
 
 
 Collapse.Collapse = Collapse;
-Collapse.CollapseUnmountClosed = Unmount;
+Collapse.UnmountClosed = UnmountClosed;
 
 
 module.exports = Collapse;


### PR DESCRIPTION
`CollapseUnmountClosed` is way too verbose and sounds strange. `UnmountClosed` makes a bit more sane