### PR TITLE
Add information about how to avoid margin "bug"

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ All other props are applied to a container that is being resized. So it is possi
 
 - initially opened Collapse elements will be statically rendered with no animation (see #19)
 - it is possible to override `overflow` and `height` styles for Collapse (see #16), and ReactCollapse may behave unexpectedly. Do it only when you definitely know you need it, otherwise, never override `overflow` and `height` styles.
+- Due to the complexity of margins and their potentially collapsible nature, ReactCollapse does not support
+(vertical) margins on their children. It might lead to the animation "jumping" to its correct height at the end of
+expanding. To avoid this, use padding instead of margin. (see #101)
+
 
 
 ## Development and testing


### PR DESCRIPTION
Due to the complicated nature of how (vertical) margins work, it's very hard to calculate the height of an element including its margins. 

Forgetting this will give you an annoying little "jump" in height as the expand-animation ends its course. 

This PR simply mentions this in the readme, so I remember why next time.

Documents #101 