### PR TITLE
Migrated deprecated React.PropTypes and React.createClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,9 @@
     "tape": "4.6.0",
     "webpack": "1.13.2",
     "webpack-dev-server": "1.16.2"
+  },
+  "dependencies": {
+    "create-react-class": "15.5.2",
+    "prop-types": "15.5.8"
   }
 }

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import reactCreateClass from 'create-react-class';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import {Motion, spring} from 'react-motion';
 import HeightReporter from 'react-height';
@@ -10,16 +12,16 @@ const PRECISION = 0.5;
 const stringHeight = height => Math.max(0, parseFloat(height)).toFixed(1);
 
 
-const Collapse = React.createClass({
+const Collapse = reactCreateClass({
   propTypes: {
-    isOpened: React.PropTypes.bool.isRequired,
-    children: React.PropTypes.node.isRequired,
-    fixedHeight: React.PropTypes.number,
-    style: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
-    springConfig: React.PropTypes.objectOf(React.PropTypes.number),
-    keepCollapsedContent: React.PropTypes.bool,
-    onRest: React.PropTypes.func,
-    onHeightReady: React.PropTypes.func
+    isOpened: PropTypes.bool.isRequired,
+    children: PropTypes.node.isRequired,
+    fixedHeight: PropTypes.number,
+    style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    springConfig: PropTypes.objectOf(PropTypes.number),
+    keepCollapsedContent: PropTypes.bool,
+    onRest: PropTypes.func,
+    onHeightReady: PropTypes.func
   },
 
 

--- a/src/example/App/FixedHeight.js
+++ b/src/example/App/FixedHeight.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import reactCreateClass from 'create-react-class';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import Collapse from '../../Collapse';
 import * as style from './style';
 
 
-const FixedHeight = React.createClass({
+const FixedHeight = reactCreateClass({
   getInitialState() {
     return {isOpened: false, keepContent: false, height: 100, fixedHeight: 200};
   },

--- a/src/example/App/Hooks.js
+++ b/src/example/App/Hooks.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import reactCreateClass from 'create-react-class';
 import {findDOMNode} from 'react-dom';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import Collapse from '../../Collapse';
@@ -13,7 +14,7 @@ const page = /Firefox/.test(navigator.userAgent) ?
 const getText = num => text.slice(0, num).map((p, i) => <p key={i}>{p}</p>);
 
 
-const Hooks = React.createClass({
+const Hooks = reactCreateClass({
   getInitialState() {
     return {isOpened: false, keepContent: false, scrollHook: true, paragraphs: 0};
   },

--- a/src/example/App/InitiallyOpened.js
+++ b/src/example/App/InitiallyOpened.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import reactCreateClass from 'create-react-class';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import Collapse from '../../Collapse';
 import * as style from './style';
 
 
-const InitiallyOpened = React.createClass({
+const InitiallyOpened = reactCreateClass({
   getInitialState() {
     return {isOpened: true, keepContent: false};
   },

--- a/src/example/App/Nested.js
+++ b/src/example/App/Nested.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import reactCreateClass from 'create-react-class';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import Collapse from '../../Collapse';
 import * as style from './style';
 import VariableHeight from './VariableHeight';
 
 
-const Nested = React.createClass({
+const Nested = reactCreateClass({
   getInitialState() {
     return {isOpened: false, keepContent: false};
   },

--- a/src/example/App/SpringConfig.js
+++ b/src/example/App/SpringConfig.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import reactCreateClass from 'create-react-class';
 import {presets} from 'react-motion';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import Collapse from '../../Collapse';
 import * as style from './style';
 
 
-const VariableHeight = React.createClass({
+const VariableHeight = reactCreateClass({
   getInitialState() {
     const preset = 'stiff';
     const {stiffness, damping} = presets[preset];

--- a/src/example/App/VariableHeight.js
+++ b/src/example/App/VariableHeight.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import reactCreateClass from 'create-react-class';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import Collapse from '../../Collapse';
 import * as style from './style';
 
 
-const VariableHeight = React.createClass({
+const VariableHeight = reactCreateClass({
   getInitialState() {
     return {isOpened: false, keepContent: false, height: 100};
   },

--- a/src/example/App/VariableText.js
+++ b/src/example/App/VariableText.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import reactCreateClass from 'create-react-class';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import Collapse from '../../Collapse';
 import text from './text.json';
@@ -8,9 +10,9 @@ import * as style from './style';
 const getText = num => text.slice(0, num).map((p, i) => <p key={i}>{p}</p>);
 
 
-const VariableText = React.createClass({
+const VariableText = reactCreateClass({
   propTypes: {
-    isOpened: React.PropTypes.bool
+    isOpened: PropTypes.bool
   },
 
 

--- a/src/example/App/index.js
+++ b/src/example/App/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import reactCreateClass from 'create-react-class';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import VariableText from './VariableText';
 import VariableHeight from './VariableHeight';
@@ -20,7 +21,7 @@ const style = {
 };
 
 
-const App = React.createClass({
+const App = reactCreateClass({
   shouldComponentUpdate,
 
 


### PR DESCRIPTION
I think we should migrate to the es6 `class` syntax and stop using `React.createClass`, but that would be another step. For now just created this PR, so people stop having deprecation warnings after migration to React v15.5. 

If you feel the same about `class`, I'll create an issue about it, so the matter won't get forgotten and neglected.