### PR TITLE
Use ES6 class for react components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     "react"
   ],
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-class-properties"
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -104,7 +104,6 @@
     "no-implicit-coercion": 2, // disallow the type conversions with shorter notations
     "no-implicit-globals": 2, // disallow var and named functions in global scope
     "no-implied-eval": 2, // disallow use of eval()-like methods
-    "no-invalid-this": 2, // disallow this keywords outside of classes or class-like objects
     "no-iterator": 2, // disallow usage of __iterator__ property
     "no-labels": 2, // disallow use of labeled statements
     "no-lone-blocks": 2, // disallow unnecessary nested blocks

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
 
   "parser": "babel-eslint",
 
-  "plugins": ["react"],
+  "plugins": ["react", "babel"],
 
   "ecmaFeatures": {
     "arrowFunctions": true,
@@ -104,6 +104,7 @@
     "no-implicit-coercion": 2, // disallow the type conversions with shorter notations
     "no-implicit-globals": 2, // disallow var and named functions in global scope
     "no-implied-eval": 2, // disallow use of eval()-like methods
+    "babel/no-invalid-this": 2, // disallow this keywords outside of classes or class-like objects
     "no-iterator": 2, // disallow usage of __iterator__ property
     "no-labels": 2, // disallow use of labeled statements
     "no-lone-blocks": 2, // disallow unnecessary nested blocks
@@ -212,7 +213,7 @@
     "max-nested-callbacks": [2, 3], // specify the maximum depth callbacks can be nested
     "max-params": [2, 5], // limits the number of parameters that can be used in the function declaration
     "max-statements": 0, // specify the maximum number of statement allowed in a function
-    "new-cap": [2, {"newIsCap": true, "capIsNew": false}], // require a capital letter for constructors
+    "babel/new-cap": [2, {"newIsCap": true, "capIsNew": false}], // require a capital letter for constructors
     "new-parens": 2, // disallow the omission of parentheses when invoking a constructor with no arguments
     "newline-after-var": 0, // require or disallow an empty newline after variable declarations
     "newline-per-chained-call": 0, // enforce newline after each call when chaining the calls
@@ -234,7 +235,7 @@
     "no-underscore-dangle": 2, // disallow dangling underscores in identifiers
     "no-unneeded-ternary": 2, // disallow the use of ternary operators when a simpler alternative exists
     "no-whitespace-before-property": 2, // disallow whitespace before properties
-    "object-curly-spacing": [2, "never"], // require or disallow padding inside curly braces (fixable)
+    "babel/object-curly-spacing": [2, "never"], // require or disallow padding inside curly braces (fixable)
     "one-var": [2, "never"], // require or disallow one variable declaration per function
     "one-var-declaration-per-line": 2, // require or disallow an newline around variable declarations
     "operator-assignment": [2, "never"], // require assignment operator shorthand where possible or prohibit it entirely
@@ -243,7 +244,7 @@
     "quote-props": [2, "as-needed"], // require quotes around object literal property names
     "quotes": [2, "single"], // specify whether backticks, double or single quotes should be used (fixable)
     "require-jsdoc": 0, // Require JSDoc comment
-    "semi": [2, "always"], // require or disallow use of semicolons instead of ASI (fixable)
+    "babel/semi": [2, "always"], // require or disallow use of semicolons instead of ASI (fixable)
     "semi-spacing": [2, {"before": false, "after": true}], // enforce spacing before and after semicolons (fixable)
     "sort-imports": 0, // sort import declarations within module
     "sort-vars": 0, // sort variables within the same declaration block

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/nkbt/react-collapse",
   "peerDependencies": {
-    "react": "^0.14 || ^15",
+    "react": ">=15.3",
     "react-motion": "^0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-core": "6.24.1",
     "babel-eslint": "7.2.2",
     "babel-loader": "6.4.1",
+    "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-object-rest-spread": "6.23.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
@@ -66,9 +67,9 @@
     "json-loader": "0.5.4",
     "nightwatch-autorun": "3.1.0",
     "parallelshell": "2.0.0",
+    "react": "15.5.4",
     "react-dom": "15.5.4",
     "react-motion": "0.4.7",
-    "react": "15.5.4",
     "rimraf": "2.6.1",
     "sinon": "2.1.0",
     "style-loader": "0.16.1",
@@ -79,7 +80,6 @@
     "webpack-dev-server": "2.4.2"
   },
   "dependencies": {
-    "create-react-class": "15.5.2",
     "prop-types": "15.5.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "cross-env": "4.0.0",
     "css-loader": "0.28.0",
     "eslint": "3.19.0",
+    "eslint-plugin-babel": "4.1.1",
     "eslint-plugin-react": "6.10.3",
     "glob": "7.1.1",
     "html-webpack-plugin": "2.28.0",

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import {Motion, spring} from 'react-motion';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 
 const SPRING_PRECISION = 1;
 
@@ -20,8 +18,8 @@ const css = {
 };
 
 
-export const Collapse = createReactClass({
-  propTypes: {
+export class Collapse extends React.PureComponent {
+  static propTypes = {
     isOpened: PropTypes.bool.isRequired,
     springConfig: PropTypes.objectOf(PropTypes.number),
     forceInitialAnimation: PropTypes.bool,
@@ -38,30 +36,29 @@ export const Collapse = createReactClass({
     onMeasure: PropTypes.func,
 
     children: PropTypes.node.isRequired
-  },
+  };
 
 
-  getDefaultProps() {
-    return {
-      forceInitialAnimation: false,
-      hasNestedCollapse: false,
-      fixedHeight: -1,
-      style: {},
-      theme: css,
-      onRender: noop,
-      onRest: noop,
-      onMeasure: noop
-    };
-  },
+  static defaultProps = {
+    forceInitialAnimation: false,
+    hasNestedCollapse: false,
+    fixedHeight: -1,
+    style: {},
+    theme: css,
+    onRender: noop,
+    onRest: noop,
+    onMeasure: noop
+  };
 
 
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+    this.state = {
       currentState: IDLING,
       from: 0,
       to: 0
     };
-  },
+  }
 
 
   componentDidMount() {
@@ -76,7 +73,7 @@ export const Collapse = createReactClass({
       }
     }
     onRest();
-  },
+  }
 
 
   componentWillReceiveProps(nextProps) {
@@ -92,10 +89,7 @@ export const Collapse = createReactClass({
     } else if (this.state.currentState === IDLING && (nextProps.isOpened || this.props.isOpened)) {
       this.setState({currentState: WAITING});
     }
-  },
-
-
-  shouldComponentUpdate,
+  }
 
 
   componentDidUpdate(_, prevState) {
@@ -121,41 +115,41 @@ export const Collapse = createReactClass({
     if (this.state.currentState === RESTING) {
       this.setState({currentState: IDLING, from, to});
     }
-  },
+  }
 
 
   componentWillUnmount() {
     cancelAnimationFrame(this.raf);
-  },
+  }
 
 
-  onContentRef(content) {
+  onContentRef = content => {
     this.content = content;
-  },
+  };
 
 
-  onWrapperRef(wrapper) {
+  onWrapperRef = wrapper => {
     this.wrapper = wrapper;
-  },
+  };
 
 
-  onRest() {
+  onRest = () => {
     this.raf = requestAnimationFrame(this.setResting);
-  },
+  };
 
 
-  setResting() {
+  setResting = () => {
     this.setState({currentState: RESTING});
-  },
+  };
 
 
-  getTo() {
+  getTo = () => {
     const {fixedHeight} = this.props;
     return (fixedHeight > -1) ? fixedHeight : this.content.clientHeight;
-  },
+  };
 
 
-  getWrapperStyle(height) {
+  getWrapperStyle = height => {
     if (this.state.currentState === IDLING && this.state.to) {
       const {fixedHeight} = this.props;
       if (fixedHeight > -1) {
@@ -169,10 +163,10 @@ export const Collapse = createReactClass({
     }
 
     return {overflow: 'hidden', height: Math.max(0, height)};
-  },
+  };
 
 
-  getMotionProps() {
+  getMotionProps = () => {
     const {springConfig} = this.props;
 
     return this.state.currentState === IDLING ? {
@@ -184,10 +178,10 @@ export const Collapse = createReactClass({
       defaultStyle: {height: this.state.from},
       style: {height: spring(this.state.to, {precision: SPRING_PRECISION, ...springConfig})}
     };
-  },
+  };
 
 
-  renderContent({height}) { // eslint-disable-line
+  renderContent = ({height}) => { // eslint-disable-line
     const {
       isOpened: _isOpened,
       springConfig: _springConfig,
@@ -220,7 +214,7 @@ export const Collapse = createReactClass({
         <div ref={this.onContentRef} className={theme.content}>{children}</div>
       </div>
     );
-  },
+  };
 
 
   render() {
@@ -231,4 +225,4 @@ export const Collapse = createReactClass({
         children={this.renderContent} />
     );
   }
-});
+}

--- a/src/UnmountClosed.js
+++ b/src/UnmountClosed.js
@@ -1,39 +1,33 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import {Collapse} from './Collapse';
 
 
-export const UnmountClosed = createReactClass({
-  propTypes: {
+export class UnmountClosed extends React.PureComponent {
+  static propTypes = {
     isOpened: PropTypes.bool.isRequired,
     onRest: PropTypes.func
-  },
+  };
 
-
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+    this.state = {
       shouldUnmount: !this.props.isOpened,
       forceInitialAnimation: !this.props.isOpened
     };
-  },
+  }
 
-
-  componentWillReceiveProps({isOpened}) {
+  componentWillReceiveProps = ({isOpened}) => {
     if (!this.props.isOpened && isOpened) {
       this.setState({
         forceInitialAnimation: true,
         shouldUnmount: false
       });
     }
-  },
+  };
 
 
-  shouldComponentUpdate,
-
-
-  onRest(...args) {
+  onRest = (...args) => {
     const {isOpened, onRest} = this.props;
 
     if (!isOpened) {
@@ -42,7 +36,7 @@ export const UnmountClosed = createReactClass({
     if (onRest) {
       onRest(...args);
     }
-  },
+  };
 
 
   render() {
@@ -65,4 +59,4 @@ export const UnmountClosed = createReactClass({
         {...props} />
     );
   }
-});
+}

--- a/src/example/App/Hooks.js
+++ b/src/example/App/Hooks.js
@@ -1,6 +1,4 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import {Collapse} from '../..';
 import text from './text.json';
 
@@ -8,9 +6,10 @@ import text from './text.json';
 const getText = num => text.slice(0, num).map((p, i) => <p key={i}>{p}</p>);
 
 
-export const Hooks = createReactClass({
-  getInitialState() {
-    return {
+export class Hooks extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
       isOpened: false,
       isResting: false,
       renderHeight: -1,
@@ -19,13 +18,9 @@ export const Hooks = createReactClass({
       width: -1,
       paragraphs: 0
     };
-  },
+  }
 
-
-  shouldComponentUpdate,
-
-
-  onRender({current, from, to}) {
+  onRender = ({current, from, to}) => {
     if (this.ref) {
       this.ref.innerHTML = `
         from: ${from.toFixed(2)},
@@ -33,18 +28,15 @@ export const Hooks = createReactClass({
         current: ${current.toFixed(2)}
       `;
     }
-  },
+  };
 
-
-  onMeasure({height, width}) {
+  onMeasure = ({height, width}) => {
     this.setState({height, width});
-  },
+  };
 
-
-  onRest() {
+  onRest = () => {
     this.setState({isResting: true});
-  },
-
+  };
 
   render() {
     const {isOpened, height, width, paragraphs} = this.state;
@@ -97,4 +89,4 @@ export const Hooks = createReactClass({
       </div>
     );
   }
-});
+}

--- a/src/example/App/Issue40.js
+++ b/src/example/App/Issue40.js
@@ -1,17 +1,13 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import {Collapse} from '../..';
 import {VariableHeight} from './VariableHeight';
 
 
-export const Issue40 = createReactClass({
-  getInitialState() {
-    return {isOpened: false};
-  },
-
-
-  shouldComponentUpdate,
+export class Issue40 extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {isOpened: false};
+  }
 
 
   render() {
@@ -36,4 +32,4 @@ export const Issue40 = createReactClass({
       </div>
     );
   }
-});
+}

--- a/src/example/App/Issue59.js
+++ b/src/example/App/Issue59.js
@@ -1,6 +1,4 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import {Collapse} from '../..';
 
 
@@ -29,23 +27,21 @@ const styles = {
 };
 
 
-export const Issue59 = createReactClass({
-  getInitialState() {
-    return {opened: 1};
-  },
+export class Issue59 extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {opened: 1};
+  }
 
 
-  shouldComponentUpdate,
-
-
-  onClick1() {
+  onClick1 = () => {
     this.setState({opened: 1});
-  },
+  };
 
 
-  onClick2() {
+  onClick2 = () => {
     this.setState({opened: 2}, () => setTimeout(() => this.setState({whatever: 1}), 50));
-  },
+  };
 
 
   render() {
@@ -70,4 +66,4 @@ export const Issue59 = createReactClass({
       </div>
     );
   }
-});
+}

--- a/src/example/App/Issue66.js
+++ b/src/example/App/Issue66.js
@@ -1,77 +1,77 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import {Collapse} from '../..';
 
 
-const Test = createReactClass({
-  propTypes: {
+class Test extends React.Component {
+  static propTypes = {
     onMount: PropTypes.func.isRequired,
     onUnmount: PropTypes.func.isRequired
-  },
+  };
 
 
   componentDidMount() {
     this.props.onMount();
-  },
+  }
 
 
   componentWillUnmount() {
     this.props.onUnmount();
-  },
+  }
 
 
   render() {
     return <div>Test</div>;
   }
-});
+}
 
 
-export const Issue66 = createReactClass({
-  propTypes: {
+export class Issue66 extends React.Component {
+  static propTypes = {
     isOpened: PropTypes.bool.isRequired
-  },
+  };
 
 
-  getInitialState() {
-    return {shouldRender: false};
-  },
+  constructor(props) {
+    super(props);
+    this.state = {shouldRender: false};
+  }
 
 
   componentWillMount() {
     this.counter = 0;
     this.messages = [];
-  },
+  }
 
 
-  onRef(ref) {
+  onRef = ref => {
     this.ref = ref;
-  },
+  };
 
 
-  onMount() {
+  onMount = () => {
     if (this.ref) {
       this.messages.unshift(`${this.counter}. Mounted`);
       this.messages = this.messages.slice(0, 5);
       this.ref.innerHTML = this.messages.join('<br />');
       this.counter = this.counter + 1;
     }
-  },
+  };
 
 
-  onUnmount() {
+  onUnmount = () => {
     if (this.ref) {
       this.messages.unshift(`${this.counter}. Unmounted`);
       this.messages = this.messages.slice(0, 5);
       this.ref.innerHTML = this.messages.join('<br />');
       this.counter = this.counter + 1;
     }
-  },
+  };
 
 
-  onChange({target: {checked}}) {
+  onChange = ({target: {checked}}) => {
     this.setState({shouldRender: checked});
-  },
+  };
 
 
   render() {
@@ -97,4 +97,4 @@ export const Issue66 = createReactClass({
       </div>
     );
   }
-});
+}

--- a/src/example/App/Nested.js
+++ b/src/example/App/Nested.js
@@ -1,17 +1,13 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import {Collapse} from '../..';
 import {VariableHeight} from './VariableHeight';
 
 
-export const Nested = createReactClass({
-  getInitialState() {
-    return {isOpened: false};
-  },
-
-
-  shouldComponentUpdate,
+export class Nested extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {isOpened: false};
+  }
 
 
   render() {
@@ -37,4 +33,4 @@ export const Nested = createReactClass({
       </div>
     );
   }
-});
+}

--- a/src/example/App/SpringConfig.js
+++ b/src/example/App/SpringConfig.js
@@ -1,27 +1,24 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import {presets} from 'react-motion';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import {Collapse} from '../..';
 
 
-export const SpringConfig = createReactClass({
-  getInitialState() {
+export class SpringConfig extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
     const preset = 'stiff';
     const {stiffness, damping} = presets[preset];
 
-    return {isOpened: false, height: 100, preset: 'stiff', stiffness, damping};
-  },
+    this.state = {isOpened: false, height: 100, preset: 'stiff', stiffness, damping};
+  }
 
 
-  shouldComponentUpdate,
-
-
-  onChangePreset({target: {value: preset}}) {
+  onChangePreset = ({target: {value: preset}}) => {
     const {stiffness, damping} = presets[preset];
 
     this.setState({preset, stiffness, damping});
-  },
+  };
 
 
   render() {
@@ -84,4 +81,4 @@ export const SpringConfig = createReactClass({
       </div>
     );
   }
-});
+}

--- a/src/example/App/VariableHeight.js
+++ b/src/example/App/VariableHeight.js
@@ -1,16 +1,12 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
-import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 import {Collapse} from '../..';
 
 
-export const VariableHeight = createReactClass({
-  getInitialState() {
-    return {isOpened: false, height: 100};
-  },
-
-
-  shouldComponentUpdate,
+export class VariableHeight extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {isOpened: false, height: 100};
+  }
 
 
   render() {
@@ -44,4 +40,4 @@ export const VariableHeight = createReactClass({
       </div>
     );
   }
-});
+}

--- a/src/example/App/VariableText.js
+++ b/src/example/App/VariableText.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import {Collapse} from '../..';
 import text from './text.json';
@@ -9,22 +8,21 @@ const getText = num => text.slice(0, num)
   .map((p, i) => <p key={i}>{p}</p>);
 
 
-export const VariableText = createReactClass({
-  propTypes: {
+export class VariableText extends React.Component {
+  static propTypes = {
     isOpened: PropTypes.bool
-  },
+  };
 
 
-  getDefaultProps() {
-    return {
-      isOpened: false
-    };
-  },
+  static defaultProps = {
+    isOpened: false
+  };
 
 
-  getInitialState() {
-    return {isOpened: this.props.isOpened, paragraphs: 0};
-  },
+  constructor(props) {
+    super(props);
+    this.state = {isOpened: this.props.isOpened, paragraphs: 0};
+  }
 
 
   render() {
@@ -59,4 +57,4 @@ export const VariableText = createReactClass({
       </div>
     );
   }
-});
+}


### PR DESCRIPTION
Note: this commit will disable eslint rule, `no-invalid-this`. Because the following code will fail this rule:
```js
class Comp extends React.Component {
  myCallback = e => {
      // Do stuff
  }
}
```

