### PR TITLE
Prevent overflow content from being hidden after collapse open

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -112,7 +112,7 @@ export class Collapse extends React.PureComponent {
       return;
     }
 
-    if (this.state.currentState === RESTING) {
+    if (this.state.currentState === RESTING || this.state.currentState === WAITING) {
       this.setState({currentState: IDLING, from, to});
     }
   }

--- a/src/example/App/Issue163.js
+++ b/src/example/App/Issue163.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import {Collapse} from '../..';
+
+
+export class Issue163 extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpened: true,
+      isOverflowOpened: true
+    };
+  }
+
+  onClick = () => this.setState({opened: !this.state.opened});
+
+  render() {
+    const {isOpened, isOverflowOpened} = this.state;
+
+    return (
+      <div>
+        <div className="config">
+          <label className="label">
+            Opened:
+            <input
+              className="input"
+              type="checkbox"
+              checked={isOpened}
+              onChange={({target: {checked}}) => this.setState({isOpened: checked})} />
+          </label>
+        </div>
+
+        <Collapse isOpened={isOpened}>
+          <div style={{height: 100, paddingTop: 50, paddingLeft: 50}} className="blob">
+            <div className="config" style={{position: 'relative'}}>
+              <label className="label">
+                Overflow opened:
+                <input
+                  className="input"
+                  type="checkbox"
+                  checked={isOverflowOpened}
+                  onChange={({target: {checked}}) => this.setState({isOverflowOpened: checked})} />
+              </label>
+              {isOverflowOpened && (
+                <div style={{width: 200, height: 200, background: 'black', position: 'absolute'}} />
+              )}
+            </div>
+          </div>
+        </Collapse>
+      </div>
+    );
+  }
+}

--- a/src/example/App/index.js
+++ b/src/example/App/index.js
@@ -11,6 +11,7 @@ import {AutoUnmount} from './AutoUnmount';
 import {Issue40} from './Issue40';
 import {Issue59} from './Issue59';
 import {Issue66} from './Issue66';
+import {Issue163} from './Issue163';
 
 import {name} from '../../../package.json';
 
@@ -98,6 +99,14 @@ export const App = () => (
       <Issue66 isOpened={true} />
       <p>Closed by default</p>
       <Issue66 isOpened={false} />
+    </section>
+
+    <section className="section">
+      <h2>
+        <a target="_blank" href="https://github.com/nkbt/react-collapse/issues/163">163</a>.
+        Overflow in collapse
+      </h2>
+      <Issue163 />
     </section>
 
   </div>


### PR DESCRIPTION
*EDIT* outdated: removed the """fix"""

Related to [#163](https://github.com/nkbt/react-collapse/issues/163).

This commit prevent setting `overflow: hidden` when a new render occur, and the `isOpened` prop is still the same (because Collapse move to WAITING state). Now, it pass to WAITING only if `isOpened` has changed. To explain better here is an animated explanation of the problem:

*before:*
![before](https://cloud.githubusercontent.com/assets/315259/25225647/77e4fe10-25c2-11e7-81d6-6a2618a2794a.gif)

*after:*
![after](https://cloud.githubusercontent.com/assets/315259/25225678/981a3ab0-25c2-11e7-8349-21992b1f89fd.gif)

I didn't understand the reason why the state is reset to WAITING either `isOpened` **OR** `nextProps.isOpened` is true, so correct me if I break something.

Thanks for the package, by the way! :smile: