### PR TITLE
Support react-motion 0.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/nkbt/react-collapse",
   "peerDependencies": {
     "react": ">=15.3",
-    "react-motion": "^0.4"
+    "react-motion": "^0.4 || ^0.5"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",


### PR DESCRIPTION
Only breaking change in 0.5 is deprecating old React (but you already know that :smile: ) - https://github.com/chenglou/react-motion/releases

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nkbt/react-collapse/171)
<!-- Reviewable:end -->
