### PR TITLE
Keeping overflow:visible when Collapse is open 

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -161,9 +161,9 @@ export class Collapse extends React.PureComponent {
     if (this.state.currentState === WAITING && !this.state.to) {
       return {overflow: 'hidden', height: 0};
     }
-    
+
     if (this.state.currentState === WAITING && (this.state.from === this.state.to)) {
-      return { overflow: 'visible' };
+      return {overflow: 'visible'};
     }
 
     return {overflow: 'hidden', height: Math.max(0, height)};

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -112,7 +112,7 @@ export class Collapse extends React.PureComponent {
       return;
     }
 
-    if (this.state.currentState === RESTING) {
+    if (this.state.currentState === RESTING || this.state.currentState === WAITING) {
       this.setState({currentState: IDLING, from, to});
     }
   }
@@ -160,6 +160,10 @@ export class Collapse extends React.PureComponent {
 
     if (this.state.currentState === WAITING && !this.state.to) {
       return {overflow: 'hidden', height: 0};
+    }
+    
+    if (this.state.currentState === WAITING && (this.state.from === this.state.to)) {
+      return { overflow: 'visible' };
     }
 
     return {overflow: 'hidden', height: Math.max(0, height)};


### PR DESCRIPTION
Referring to #166, when the Collapse is open, after a re-render the `overflow` property is overridden, causing the overflow content to be hidden again.
This change keeps the overflow content `visible` when the Collapse is open.