### PR TITLE
Update Readme Example GIF Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Component-wrapper for collapse animation with react-motion for elements with variable (and dynamic) height
 
 
-![React Collapse](src/example/react-collapse.gif)
+![React Collapse](example/react-collapse.gif)
 
 
 ## Installation


### PR DESCRIPTION
This is a follow-up on this issue https://github.com/nkbt/react-collapse/issues/194

The Readme file has a link to an example GIF. The path is currently linking to `https://github.com/nkbt/react-collapse/blob/master/src/example/react-collapse.gif`

But the file is actually in `https://github.com/nkbt/react-collapse/blob/master/example/react-collapse.gif`

I just altered the path to remove the `src/`

Here's a pic of it working now
![image](https://user-images.githubusercontent.com/4755444/30625071-eaf69eb0-9d75-11e7-800a-690dd74dd24d.png)

