### PR TITLE
Stop jumping when content has margins

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ One or multiple children with static, variable or dynamic height.
 
 #### `hasNestedCollapse`: PropTypes.bool (default: false)
 
-If Collapse component has more Collapse components inside, it needs `hasNestedCollapse` to be set 
+If Collapse component has more Collapse components inside, it needs `hasNestedCollapse` to be set
 to avoid delayed animations. See https://github.com/nkbt/react-collapse/issues/76 for tech details.
 
 ```js
@@ -199,7 +199,7 @@ Callback function for every re-render while animating.
 Passes `current` height, as well as `from`/`to` heights.
 
 **DANGEROUS** use with caution, may have huge performance impact if used improperly. Never do `setState` with it, since it is running while rendering and React will shoot Warning.
- 
+
 Possible usage: synchronous scrolling of some other component
 ```js
 <Collapse onRender={({current, from, to}) => (this.anotherComponent.scrollTop = current)}>
@@ -238,47 +238,47 @@ All other props are applied to a container that is being resized. So it is possi
   ```js
   import Collapse from 'react-collapse';
   ```
-  
+
   V3
   ```js
   import {Collapse} from 'react-collapse';
   ```
-  
+
 2. Default behavior changed to never unmount collapsed element. To actually unmount use extra provided component `UnmountCollapsed`
 
-  V2: 
+  V2:
   ```js
   import Collapse from 'react-collapse';
-  
+
   <Collapse isOpened={true || false}>
     <div>Random content</div>
   </Collapse>
-  ```  
+  ```
 
-  V3: 
+  V3:
   ```js
   import {UnmountClosed as Collapse} from 'react-collapse';
-  
+
   <Collapse isOpened={true || false}>
     <div>Random content</div>
   </Collapse>
-  ```  
+  ```
 
 3. `onHeightReady` renamed to `onMeasure` which now takes object of shape `{width, height}`
 
-  V2: 
+  V2:
   ```js
   <Collapse onHeightReady={height => console.log(height)}>
     <div>Random content</div>
   </Collapse>
-  ```  
+  ```
 
-  V3: 
+  V3:
   ```js
   <Collapse onMeasure={({height, width}) => console.log(height, width)}>
     <div>Random content</div>
   </Collapse>
-  ```  
+  ```
 
 4. Some new props/features: `hasNestedCollapse`, `forceInitialAnimation`, `onRender`, etc
 

--- a/example/app.css
+++ b/example/app.css
@@ -16,8 +16,8 @@
 }
 
 .text p {
-  margin: 0;
-  padding: 10px;
+  margin: 10px 0;
+  padding: 0 10px;
 }
 
 .config {

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -167,6 +167,13 @@ export class Collapse extends React.PureComponent {
     return {overflow: 'hidden', height: Math.max(0, height)};
   };
 
+  getContentStyle = () => {
+    if (this.state.currentState === IDLING && this.props.isOpened) {
+      return null;
+    }
+    return {overflowY: 'auto'};
+  };
+
 
   getMotionProps = () => {
     const {springConfig} = this.props;
@@ -213,7 +220,12 @@ export class Collapse extends React.PureComponent {
         className={theme.collapse}
         style={{...this.getWrapperStyle(Math.max(0, height)), ...style}}
         {...props}>
-        <div ref={this.onContentRef} className={theme.content}>{children}</div>
+        <div
+          ref={this.onContentRef}
+          className={theme.content}
+          style={this.getContentStyle()}>
+          {children}
+        </div>
       </div>
     );
   };


### PR DESCRIPTION
This pull request fixes a bug that's been causing a lot of issues - namely the margins of collapsed content not being included when the height is being calculated.

This is done by introducing what's called a temporary new [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context) to the content when it's not stable and opened. If that's a new CSS concept to you, that's okay - I never heard of it either. It's basically what happens when you throw a `overflow-y: auto` on a DOM element The end effect is that it clears any margins, which in turn makes it possible to measure the "real" height of the content without changing a lot of margins to paddings.

This PR also changes the example CSS file so that it uses default margins instead of paddings to separate sample paragraphs.

This is a WIP, but it seems to be working. What do you think?