### PR TITLE
Remove iframe from tab sequence

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -94,6 +94,7 @@ export class Collapse extends React.Component {
           className={theme.content}>
           <iframe
             ref={this.onSensorRef}
+            tabIndex="-1"
             title="Element resize sensor"
             style={{
               display: 'block',


### PR DESCRIPTION
When using the tab key with the current implementation, the hidden iframe takes tab focus. This removes that ability making sure the user doesn't have to press the key twice to get to the first item in the list (or the next list if it is collapsed).