### PR TITLE
Fix UnmountClosed for new React

### DIFF
--- a/example/App/index.js
+++ b/example/App/index.js
@@ -15,7 +15,6 @@ export const App = () => (
   <div className="app">
 
     <h1>@nkbt/react-collapse</h1>
-
     <section className="section">
       <h2>Variable text</h2>
       <VariableText />
@@ -87,6 +86,5 @@ export const App = () => (
       </h2>
       <Issue163 />
     </section>
-
   </div>
 );

--- a/src/UnmountClosed.js
+++ b/src/UnmountClosed.js
@@ -16,17 +16,18 @@ export class UnmountClosed extends React.PureComponent {
   };
 
 
-  static getDerivedStateFromProps(nextProps) {
-    return {
-      isResting: false,
-      isOpened: nextProps.isOpened
-    };
-  }
-
-
   constructor(props) {
     super(props);
     this.state = {isResting: true, isOpened: props.isOpened, isInitialRender: true};
+  }
+
+
+  componentDidUpdate(prevProps) {
+    const {isOpened} = this.props;
+    if (prevProps.isOpened !== isOpened) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({isResting: false, isOpened, isInitialRender: false});
+    }
   }
 
 


### PR DESCRIPTION
In newer versions of React `getDerivedStateFromProps` was called on any update even if props haven't changed. Replacing it with componentDidUpdate fix the issue of never getting into `isResting` state