### PR TITLE
Avoid using Object.assign os IE11 works again

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,10 @@ module.exports = {
       multiline: true,
       consistent: true,
       minProperties: 0
-    }]
+    }],
+
+    'react/state-in-constructor': 'off',
+    'react/jsx-one-expression-per-line': 'off',
+    'react/no-array-index-key': 'off'
   }
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "predist": "rm -rf ./build",
     "dist": "NODE_ENV=production webpack-cli --config ./webpack/dist.config.js && NODE_ENV=production webpack-cli --config ./webpack/min.config.js",
     "preghPages": "yarn pub",
-    "ghPages": "gh-pages --dist ./pub --repo git@github.com:nkbt/react-collapse.git --user nik@butenko.me --branch gh-pages --message 'Publish examples' ",
+    "ghPages": "gh-pages --dist ./pub --repo git@github.com:nkbt/react-collapse.git --user nik@butenko.me --branch gh-pages --message 'Publish examples'",
     "prelib": "rm -rf ./lib",
     "lib": "NODE_ENV=production babel src --out-dir lib",
     "lint": "eslint .",

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -153,16 +153,21 @@ export class Collapse extends React.Component {
   };
 
 
+  onRefContainer = container => {
+    this.container = container;
+  };
+
+
+  onRefContent = content => {
+    this.content = content;
+  };
+
+
   render() {
     const {theme, children} = this.props;
     return (
-      <div
-        ref={container => Object.assign(this, {container})}
-        className={theme.collapse}
-        style={this.initialStyle}>
-        <div
-          ref={content => Object.assign(this, {content})}
-          className={theme.content}>
+      <div ref={this.onRefContainer} className={theme.collapse} style={this.initialStyle}>
+        <div ref={this.onRefContent} className={theme.content}>
           {children}
         </div>
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,10 @@ const {Collapse} = require('./Collapse');
 const {UnmountClosed} = require('./UnmountClosed');
 
 
-Object.assign(UnmountClosed, {Collapse, UnmountClosed});
+// Default export
 module.exports = UnmountClosed;
+
+
+// Extra "named exports"
+UnmountClosed.Collapse = Collapse;
+UnmountClosed.UnmountClosed = UnmountClosed;


### PR DESCRIPTION
Fixes "v5 doesn't work in IE11 anymore" #256