### PR TITLE
Accessibility enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install --save react-collapse
 ### yarn
 
 ```sh
-yarn add react-collapse 
+yarn add react-collapse
 ```
 
 ### 1998 Script Tag:
@@ -118,6 +118,10 @@ Which ends up in the following markup:
 
 **IMPORTANT**: these are not style objects, but class names!
 
+### `accessibilityId`: PropTypes.string
+
+The paradigm of this library is to not make a decision about how you want to toggle the collapse.
+The trade-off here is that accessibility cannot be fully baked in. We provide [2 examples](./example/App/Accessible.js) on how to make an accessible collapse by tying together the control of the collapse and the collapse itself with `props.accessibilityId`.
 
 ### `onRest`, `onWork`: PropTypes.func
 
@@ -130,7 +134,7 @@ const arg = {
   isFullyClosed: true || false, // `true` only when Collapse is fully closed and height is zero
   isOpened: true || false, // `true` if Collapse has any non-zero height
   containerHeight: 123, // current pixel height of Collapse container (changes until reaches `contentHeight`)
-  contentHeight: 123 // determined height of supplied Content 
+  contentHeight: 123 // determined height of supplied Content
 }
 ```
 
@@ -165,10 +169,10 @@ Example: [example/App/ForceInitialAnimation.js](example/App/ForceInitialAnimatio
 
 ### `checkTimeout`: PropTypes.number
 
-Number in `ms`. 
+Number in `ms`.
 
 Collapse will check height after thins timeout to determine if animation is completed, the shorter the number - the faster `onRest` will be triggered and the quicker `hight: auto` will be applied. The downside - more calculations.
-Default value is: `50`. 
+Default value is: `50`.
 
 
 ### Pass-through props
@@ -221,7 +225,7 @@ The implications is that you will need to update your CSS with transition:
     ```
 
 - `checkTimeout` number in `ms`. Collapse will check height after thins timeout to determine if animation is completed, the shorter the number - the faster `onRest` will be triggered and the quicker `hight: auto` will be applied. The downside - more calculations.
-    Default value is: `50`. 
+    Default value is: `50`.
 
 ### 3. Deprecated props (not available in `v5`)
 - ~~Pass-through props~~ - any unknown props passed to `Collapse` component will be ignored

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ yarn add react-collapse
 
 ## Usage
 
-Default behaviour, never unmounts content
+### 1. Content is always mounted (default)
 
 ```js
 import {Collapse} from 'react-collapse';
@@ -53,7 +53,11 @@ import {Collapse} from 'react-collapse';
 </Collapse>
 ```
 
-If you want to unmount collapsed content, use `Unmount` component provided as:
+---
+
+### 2. Content unmounts when collapsed
+
+Use `Unmount` component provided as:
 
 ```js
 import {UnmountClosed} from 'react-collapse';
@@ -66,6 +70,11 @@ import {UnmountClosed} from 'react-collapse';
 
 Example [example/App/AutoUnmount.js](example/App/AutoUnmount.js)
 
+---
+
+### 3. Controlled and accessible
+
+If you want a controlled and accessible implementation, check out this [example](example/App/Accessible.js)
 
 ## Options
 
@@ -118,10 +127,6 @@ Which ends up in the following markup:
 
 **IMPORTANT**: these are not style objects, but class names!
 
-### `accessibilityId`: PropTypes.string
-
-The paradigm of this library is to not make a decision about how you want to toggle the collapse.
-The trade-off here is that accessibility cannot be fully baked in. We provide [2 examples](./example/App/Accessible.js) on how to make an accessible collapse by tying together the control of the collapse and the collapse itself with `props.accessibilityId`.
 
 ### `onRest`, `onWork`: PropTypes.func
 

--- a/example/App/Accessible.js
+++ b/example/App/Accessible.js
@@ -1,0 +1,64 @@
+import React, {useState} from 'react';
+import {Collapse} from '../../src';
+
+export function Accessible() {
+  const height = 100;
+
+  const accessibilityIds = {
+    checkbox: 'accessible-marker-example1',
+    button: 'accessible-marker-example2'
+  };
+
+  const [state, setState] = useState({
+    isCheckboxCollapseOpen: false,
+    isButtonCollapseOpen: false
+  });
+
+  return (
+    <div className="accessible">
+      <ul>
+        <li>
+          <div>
+            <h6>With a checkbox</h6>
+            <div className="config">
+              <label className="label">
+                Opened:
+                <input
+                  className="input"
+                  type="checkbox"
+                  aria-controls={accessibilityIds.checkbox}
+                  checked={state.isCheckboxCollapseOpen}
+                  onChange={({target: {checked}}) => setState({isCheckboxCollapseOpen: checked})} />
+              </label>
+            </div>
+            <Collapse
+              isOpened={state.isCheckboxCollapseOpen}
+              accessibilityId={accessibilityIds.checkbox}>
+              <div style={{height}} className="blob" />
+            </Collapse>
+          </div>
+        </li>
+
+        <li>
+          <div>
+            <h6>With a button</h6>
+            <div className="config">
+              <button
+                aria-controls={accessibilityIds.button}
+                aria-expanded={state.isButtonCollapseOpen}
+                onClick={() => setState({isButtonCollapseOpen: !state.isButtonCollapseOpen})}
+                type="button">
+                Reveal content
+              </button>
+            </div>
+            <Collapse
+              isOpened={state.isButtonCollapseOpen}
+              accessibilityId={accessibilityIds.button}>
+              <div style={{height}} className="blob" />
+            </Collapse>
+          </div>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/example/App/Accessible.js
+++ b/example/App/Accessible.js
@@ -31,10 +31,8 @@ export function Accessible() {
                   onChange={({target: {checked}}) => setState({isCheckboxCollapseOpen: checked})} />
               </label>
             </div>
-            <Collapse
-              isOpened={state.isCheckboxCollapseOpen}
-              accessibilityId={accessibilityIds.checkbox}>
-              <div style={{height}} className="blob" />
+            <Collapse isOpened={state.isCheckboxCollapseOpen}>
+              <div style={{height}} id={accessibilityIds.checkbox} className="blob" />
             </Collapse>
           </div>
         </li>
@@ -52,9 +50,8 @@ export function Accessible() {
               </button>
             </div>
             <Collapse
-              isOpened={state.isButtonCollapseOpen}
-              accessibilityId={accessibilityIds.button}>
-              <div style={{height}} className="blob" />
+              isOpened={state.isButtonCollapseOpen}>
+              <div style={{height}} id={accessibilityIds.button} className="blob" />
             </Collapse>
           </div>
         </li>

--- a/example/App/index.js
+++ b/example/App/index.js
@@ -4,6 +4,7 @@ import {VariableHeight} from './VariableHeight';
 import {InitiallyOpened} from './InitiallyOpened';
 import {Nested} from './Nested';
 import {Hooks} from './Hooks';
+import {Accessible} from './Accessible';
 import {AutoUnmount} from './AutoUnmount';
 import {ForceInitialAnimation} from './ForceInitialAnimation';
 
@@ -49,6 +50,11 @@ export const App = () => (
     <section className="section">
       <h2>Hooks</h2>
       <Hooks />
+    </section>
+
+    <section className="section">
+      <h2>Accessible examples</h2>
+      <Accessible />
     </section>
 
     <section className="section">

--- a/example/app.css
+++ b/example/app.css
@@ -48,6 +48,11 @@ body {
   font-family: Menlo, Consolas, Monospaced, monospace;
 }
 
+.accessible ul {
+  list-style: none;
+  padding-inline-start: 0;
+}
+
 .ReactCollapse--collapse {
   max-width: 800px;
   border: 1px solid rgba(3, 169, 244, 0.3);
@@ -58,4 +63,3 @@ body {
 
 .ReactCollapse--content {
 }
-

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 export class Collapse extends React.Component {
   static propTypes = {
+    accessibilityId: PropTypes.string,
     theme: PropTypes.shape({
       collapse: PropTypes.string,
       content: PropTypes.string
@@ -21,6 +22,7 @@ export class Collapse extends React.Component {
 
 
   static defaultProps = {
+    accessibilityId: '',
     theme: {
       collapse: 'ReactCollapse--collapse',
       content: 'ReactCollapse--content'
@@ -164,10 +166,14 @@ export class Collapse extends React.Component {
 
 
   render() {
-    const {theme, children} = this.props;
+    const {accessibilityId, theme, children, isOpened} = this.props;
     return (
-      <div ref={this.onRefContainer} className={theme.collapse} style={this.initialStyle}>
-        <div ref={this.onRefContent} className={theme.content}>
+      <div
+        ref={this.onRefContainer}
+        className={theme.collapse}
+        style={this.initialStyle}
+        aria-hidden={!isOpened}>
+        <div ref={this.onRefContent} className={theme.content} id={accessibilityId}>
           {children}
         </div>
       </div>

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 
 export class Collapse extends React.Component {
   static propTypes = {
-    accessibilityId: PropTypes.string,
     theme: PropTypes.shape({
       collapse: PropTypes.string,
       content: PropTypes.string
@@ -22,7 +21,6 @@ export class Collapse extends React.Component {
 
 
   static defaultProps = {
-    accessibilityId: '',
     theme: {
       collapse: 'ReactCollapse--collapse',
       content: 'ReactCollapse--content'
@@ -166,14 +164,14 @@ export class Collapse extends React.Component {
 
 
   render() {
-    const {accessibilityId, theme, children, isOpened} = this.props;
+    const {theme, children, isOpened} = this.props;
     return (
       <div
         ref={this.onRefContainer}
         className={theme.collapse}
         style={this.initialStyle}
         aria-hidden={!isOpened}>
-        <div ref={this.onRefContent} className={theme.content} id={accessibilityId}>
+        <div ref={this.onRefContent} className={theme.content}>
           {children}
         </div>
       </div>


### PR DESCRIPTION
As discussed in https://github.com/nkbt/react-collapse/issues/255 , accessibility for collapses/accordions are difficult and not as simple as dealing with `aria-hidden`. I've used it anyways, but also provided a prop and documentation on how to make `react-collapse` usages more accessible.

Resolves #255