### PR TITLE
Allow to override className via className

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 export class Collapse extends React.Component {
   static propTypes = {
+    className: PropTypes.string,
     theme: PropTypes.shape({
       collapse: PropTypes.string,
       content: PropTypes.string
@@ -164,9 +165,9 @@ export class Collapse extends React.Component {
 
 
   render() {
-    const {theme, children} = this.props;
+    const {theme, children, className} = this.props;
     return (
-      <div ref={this.onRefContainer} className={theme.collapse} style={this.initialStyle}>
+      <div ref={this.onRefContainer} className={className || theme.collapse} style={this.initialStyle}>
         <div ref={this.onRefContent} className={theme.content}>
           {children}
         </div>


### PR DESCRIPTION
Currently, this component doesn't work with any CSS-in-JS framework like `styled-components` or `emotion`. Because it doesn't accept className props. This commit was fixed that issue.

Example with emotion & theme-ui
```ts
import { css } from 'theme-ui';
import styled from '@emotion/styled';

const block = css({
  transition: 'height 300ms',
  '.ReactCollapse--content': {
    display: 'flex',
    flexDirection: 'column',
    '> a': {
      color: '#898F9A',
      fontSize: [20, 14],
      lineHeight: ['32px', '24px'],
      marginTop: 15,
      textDecoration: 'none',
    },
  },
});

const StyledCollapse = styled(Collapse)(block)
```

Bellow component was build with react-collapse & this fix. 😄 Thank you for develop.
![ezgif-6-7d5d783d4248](https://user-images.githubusercontent.com/12751435/82608214-70784380-9be4-11ea-9043-31ffe2b88a88.gif)

