### PR TITLE
Allow React 17 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/nkbt/react-collapse",
   "peerDependencies": {
-    "react": "^16.3.0"
+    "react": ">=16.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
Hi @nkbt!

I bumped the peerDependencies version of react to include v17, since I was getting these warnings:

```
warning "react-collapse@5.0.1" has incorrect peer dependency "react@^16.3.0"
```

Thanks!