### PR TITLE
Don't call clearTimeout through global 

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -83,12 +83,12 @@ export class Collapse extends React.Component {
 
 
   componentWillUnmount() {
-    global.clearTimeout(this.timeout);
+    clearTimeout(this.timeout);
   }
 
 
   onResize = () => {
-    global.clearTimeout(this.timeout);
+    clearTimeout(this.timeout);
 
     if (!this.container || !this.content) {
       return;


### PR DESCRIPTION
This fixes an issue I had using [vite](https://vitejs.dev/) with react-collapse. Since vite bundles the [dependencies as native esm](https://vitejs.dev/guide/dep-pre-bundling.html#the-why), it uses the code from `/src`. I'm unsure why it bundles src and not lib. But the problem is that global.clearTimeout result in an error since global is not replaced (like it is in the webpack build).