### PR TITLE
transition as a property

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -9,6 +9,7 @@ export class Collapse extends React.Component {
       content: PropTypes.string
     }),
     isOpened: PropTypes.bool.isRequired,
+    transition: PropTypes.string,
     initialStyle: PropTypes.shape({
       height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       overflow: PropTypes.string
@@ -25,6 +26,7 @@ export class Collapse extends React.Component {
       collapse: 'ReactCollapse--collapse',
       content: 'ReactCollapse--content'
     },
+    transition: undefined,
     initialStyle: undefined,
     onRest: undefined,
     onWork: undefined,
@@ -47,6 +49,9 @@ export class Collapse extends React.Component {
       this.initialStyle = props.isOpened
         ? {height: 'auto', overflow: 'initial'}
         : {height: '0px', overflow: 'hidden'};
+    }
+    if (props.transition) {
+      this.initialStyle = { ...this.initialStyle, transition: props.transition };
     }
   }
 

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -51,7 +51,7 @@ export class Collapse extends React.Component {
         : {height: '0px', overflow: 'hidden'};
     }
     if (props.transition) {
-      this.initialStyle = { ...this.initialStyle, transition: props.transition };
+      this.initialStyle = {...this.initialStyle, transition: props.transition};
     }
   }
 

--- a/src/UnmountClosed.js
+++ b/src/UnmountClosed.js
@@ -6,12 +6,14 @@ import {Collapse} from './Collapse';
 export class UnmountClosed extends React.PureComponent {
   static propTypes = {
     isOpened: PropTypes.bool.isRequired,
+    transition: PropTypes.string,
     onWork: PropTypes.func,
     onRest: PropTypes.func
   };
 
   static defaultProps = {
     onWork: undefined,
+    transition: undefined,
     onRest: undefined
   };
 


### PR DESCRIPTION
Hi friend! 
I created a pull request in which the transition is added as a property. 
Now it is not necessary to create a CSS class.
Now we need to assign the property: transition="height 350ms linear".
What do you think about that?

Alternatively, we can add it using a transition support.