### PR TITLE
fix resize on update children components & simplified

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -64,19 +64,6 @@ export class Collapse extends React.Component {
       || Object.keys(theme).some(c => theme[c] !== nextProps.theme[c]);
   }
 
-
-  getSnapshotBeforeUpdate() {
-    if (!this.container || !this.content) {
-      return null;
-    }
-    if (this.container.style.height === 'auto') {
-      const {clientHeight: contentHeight} = this.content;
-      this.container.style.height = `${contentHeight}px`;
-    }
-    return null;
-  }
-
-
   componentDidUpdate() {
     this.onResize();
   }
@@ -92,6 +79,11 @@ export class Collapse extends React.Component {
 
     if (!this.container || !this.content) {
       return;
+    }
+
+    if (this.container.style.height === 'auto') {
+      const {clientHeight: contentHeight} = this.content;
+      this.container.style.height = `${contentHeight}px`;
     }
 
     const {isOpened, checkTimeout} = this.props;


### PR DESCRIPTION
if child components are redrawn with a new height, this is not always tracked in getSnapshotBeforeUpdate. Therefore, I moved the height setting logic to onResize. In addition, getSnapshotBeforeUpdate assumes the use of previous states, but here it is not necessary, onResize has everything you need